### PR TITLE
fix: allow auto creation of topics

### DIFF
--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -164,13 +164,7 @@ export class KafkaPubSub extends PubSubEngine {
         let topics =  metadata.topics.map(topic => topic.name);
         this.logger.info('Connected, found topics: %s', topics);
         
-        if (topics.includes(this.options.topic)) {
-          resolve(producer);
-        } else {
-          this.logger.error('Could not find requested topic %s', this.options.topic);
-          producer.disconnect()
-          reject('Could not find requested topic %s')
-        }
+        resolve(producer);
       })
 
       this.logger.info("Connecting producer ...")
@@ -232,16 +226,10 @@ export class KafkaPubSub extends PubSubEngine {
         let topics =  metadata.topics.map(topic => topic.name);
         this.logger.info('Connected, found topics: %s', topics);
         
-        if (topics.includes(topic)) {
-          this.logger.info("Subscribing to %s", topic)
+        this.logger.info("Subscribing to %s", topic)
           consumer.subscribe([topic]);
           consumer.consume();
           resolve(consumer);
-        } else {
-          this.logger.error('Could not find requested topic %s', topic);
-          consumer.disconnect()
-          reject('Could not find requested topic %s')
-        }
       })
 
       this.logger.info("Connecting consumer ...")


### PR DESCRIPTION
Currently this engine throws an error if a topic does not exist. This happens within the PubSub library on user application, not in Kafka server).

It is possible to configure topic auto-creation in Kafka with the `auto.topic.create.enable` flag. However because the validation was happening from this library, it was rejected too early and was never able to be created. This does not respect the Kafka server configuration.

It is much simpler and better to let the Kafka server handle this validation.