### PR TITLE
added topic name to error when didnt find topic

### DIFF
--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -169,7 +169,7 @@ export class KafkaPubSub extends PubSubEngine {
         } else {
           this.logger.error('Could not find requested topic %s', this.options.topic);
           producer.disconnect()
-          reject('Could not find requested topic %s')
+          reject('Could not find requested topic ' + this.options.topic)
         }
       })
 


### PR DESCRIPTION
Fixed the issue:  
error was logged correctly but when trying to subscribe, got the message:
"error": {
    "name": "FormatedError",
    "message": "Unknown error",
    "originalError": "Could not find requested topic %s"
  }

added the topic name instead of "%s"